### PR TITLE
config for better test output

### DIFF
--- a/2025-Code/build.gradle
+++ b/2025-Code/build.gradle
@@ -77,6 +77,10 @@ dependencies {
 test {
     useJUnitPlatform()
     systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
+    testLogging {
+		events "failed"
+		exceptionFormat "full"
+	}
 }
 
 // Simulation configuration (e.g. environment variables).


### PR DESCRIPTION
Now you can see the expected and actual

ClawTest > testClaw() FAILED
    org.opentest4j.AssertionFailedError: expected: <1.0> but was: <0.0>
        at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at app//org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:70)
        at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:65)
        at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:889)
        at app//frc.robot.subsystem.ClawTest.testClaw(ClawTest.java:14)