### PR TITLE
fixed yaw

### DIFF
--- a/2025-Code/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/2025-Code/src/main/java/frc/robot/subsystems/Swerve.java
@@ -70,12 +70,12 @@ public class Swerve extends CommandSwerveDrivetrain {
 
   /**
    * Returns the yaw of the robot, which is the rotation of the robot around the
-   * vertical axis.
+   * vertical axis, from -180 -> 180 as defined by the SWERVE, not pigeon.
    * 
    * @return The yaw of the robot in degrees.
    */
   public double getYaw() {
-    return getPigeon2().getYaw().getValueAsDouble();
+    return getCurrentPose().getRotation().getDegrees();
   }
 
   /**


### PR DESCRIPTION
basically, the pigeon and swerve are using maintaining two different yaw values, so we need to just use the swerve value and update with limelight at some point. If pigeon yaw is used at all, it should be a duplicate of that swerve yaw.