### PR TITLE
Organize tuning values in network tables

### DIFF
--- a/2025-Code/simgui-ds.json
+++ b/2025-Code/simgui-ds.json
@@ -1,9 +1,4 @@
 {
-  "System Joysticks": {
-    "window": {
-      "enabled": false
-    }
-  },
   "keyboardJoysticks": [
     {
       "axisConfig": [
@@ -92,6 +87,12 @@
       "axisCount": 0,
       "buttonCount": 0,
       "povCount": 0
+    }
+  ],
+  "robotJoysticks": [
+    {
+      "guid": "78696e70757401000000000000000000",
+      "useGamepad": true
     }
   ]
 }

--- a/2025-Code/src/main/java/frc/robot/subsystems/NetworkTables/ArmNT.java
+++ b/2025-Code/src/main/java/frc/robot/subsystems/NetworkTables/ArmNT.java
@@ -38,17 +38,17 @@ public class ArmNT extends Arm {
 
         motorVoltagePub = voltage.publish();
         motorVoltagePub.setDefault(0.0);
-        m_PIDTuner = new PIDTuner("arm");
+        m_PIDTuner = new PIDTuner("arm/{tuning}PIDF");
 
         m_PIDTuner.setP(m_previousP);
         m_PIDTuner.setI(m_previousI);
         m_PIDTuner.setD(m_previousD);
 
-        m_FFTuner = new FFTuner("arm");
+        m_FFTuner = new FFTuner("arm/{tuning}PIDF");
 
         m_FFTuner.setFF(m_previousFF);
 
-        m_MaxMotionTuner = new MaxMotionTuner("arm");
+        m_MaxMotionTuner = new MaxMotionTuner("arm/{tuning}MaxMotion");
 
         m_MaxMotionTuner.setMaxVelocity(m_previousMaxVelocity);
         m_MaxMotionTuner.setMaxAcceleration(m_previousMaxAcceleration);

--- a/2025-Code/src/main/java/frc/robot/subsystems/NetworkTables/ElevatorNT.java
+++ b/2025-Code/src/main/java/frc/robot/subsystems/NetworkTables/ElevatorNT.java
@@ -42,16 +42,16 @@ public class ElevatorNT extends Elevator {
         lowLimitPub = at_limit.publish();
         lowLimitPub.setDefault(false);
 
-        m_PIDTuner = new PIDTuner("elevator");
+        m_PIDTuner = new PIDTuner("elevator/{tuning}PIDF");
 
         m_PIDTuner.setP(m_previousP);
         m_PIDTuner.setI(m_previousI);
         m_PIDTuner.setD(m_previousD);
 
-        m_FFTuner = new FFTuner("elevator");
+        m_FFTuner = new FFTuner("elevator/{tuning}PIDF");
         m_FFTuner.setFF(m_previousFF);
 
-        m_MaxMotionTuner = new MaxMotionTuner("elevator");
+        m_MaxMotionTuner = new MaxMotionTuner("elevator/{tuning}MaxMotion");
 
         m_MaxMotionTuner.setMaxVelocity(m_previousMaxVelocity);
         m_MaxMotionTuner.setMaxAcceleration(m_previousMaxAcceleration);


### PR DESCRIPTION
alphabetical order bugged me for these. I think this will be nice in the future when tuning elevator and arm. the `{` is after lower case letters in ASCII, so that puts the `{tuning}` at the end of the list.

compact:
![image](https://github.com/user-attachments/assets/c3d227af-6307-4b91-add5-fbe492883a02)

expanded for tuning:
![image](https://github.com/user-attachments/assets/3d685d18-1486-4982-b0dc-1f0da58552d1)
