### PR TITLE
ICE 3/17 and 3/18

### DIFF
--- a/2025-Code/src/main/java/frc/robot/Constants.java
+++ b/2025-Code/src/main/java/frc/robot/Constants.java
@@ -194,7 +194,7 @@ public final class Constants {
                 public static final int UNLOCK_GRABBER_POSITION = -43;
                 public static final int GRANNY_GRABBER_POSITION = 0;
 
-                public static final double RATCHET_LOCK_POSITION = 0.84;
+                public static final double RATCHET_LOCK_POSITION = 0.7;
                 public static final double RATCHET_UNLOCK_POSITION = 1;
 
                 public static final double CLIMB_kP = 0.75;

--- a/2025-Code/src/main/java/frc/robot/Constants.java
+++ b/2025-Code/src/main/java/frc/robot/Constants.java
@@ -53,7 +53,7 @@ public final class Constants {
                                 -1, -1, -1, -1, -1, -120, 180, 120, 60, 0, -60 };
                 public static final double APRILTAG_ALIGN_LIMIT = 1.5;
                 public static final double AUTO_ALIGN_P = 4;
-                public static final double AUTO_ALIGN_D = .02;
+                public static final double AUTO_ALIGN_D = .005; // 0.02
                 public static final double STALL_TORQUE = 7.09;
                 public static final double STALL_CURRENT = 366;
                 public static final double FREE_CURRENT_AMPS = 2;
@@ -72,7 +72,8 @@ public final class Constants {
                 public static final int MOTOR_ID = 2;
                 public static final int FOLLOWER_ID = 3;
                 public static final int CURRENT_LIMIT = 60;
-                public static final double DEFAULT = 10.0;
+                public static final double DEFAULT_NO_CORAL = 17.0;
+                public static final double DEFAULT_WITH_CORAL = 0;
                 public static final double BOTTOM_POSITION = 0.0;
                 public static final double STAGE_ONE_UP = 26.0;
                 public static final double CORAL_INTAKE = 34;
@@ -109,14 +110,15 @@ public final class Constants {
 
                 public static final double STARTING_POSITION = 180;
                 public static final double DEFAULT_POSITION = 160;
-                public static final double DEFAULT_BACK_POSITION = 230;
+                public static final double DEFAULT_NO_GP = 180;
+                public static final double SAFE_BACK_POS = 230;
                 public static final double GROUND_ALGAE_POSITION = 95;
                 public static final double CORAL_STATION_POSITION = 323;
                 public static final double L1_UNDERHAND = 335.0;
                 public static final double L1_POSITION = 140.0;
                 public static final double L2_POSITION = 135.0;
                 public static final double L3_POSITION = 135.0;
-                public static final double L4_POSITION = 133.0;
+                public static final double L4_POSITION = 140.0;
                 public static final double BARGE_POSITION = 159.0;
                 public static final double PROCESSOR_POSITION = 270.0;
                 public static final double EVACUATE_ANGLE = 15.0;

--- a/2025-Code/src/main/java/frc/robot/Constants.java
+++ b/2025-Code/src/main/java/frc/robot/Constants.java
@@ -53,7 +53,7 @@ public final class Constants {
                                 -1, -1, -1, -1, -1, -120, 180, 120, 60, 0, -60 };
                 public static final double APRILTAG_ALIGN_LIMIT = 1.5;
                 public static final double AUTO_ALIGN_P = 4;
-                public static final double AUTO_ALIGN_D = .005; // 0.02
+                public static final double AUTO_ALIGN_D = 0.02;
                 public static final double STALL_TORQUE = 7.09;
                 public static final double STALL_CURRENT = 366;
                 public static final double FREE_CURRENT_AMPS = 2;
@@ -83,12 +83,12 @@ public final class Constants {
                 public static final double SCORE_ALGAE_PROCESSOR = 25.0;
                 public static final double L1 = 11.0;
                 public static final double L2 = 16.0;
-                public static final double L3 = 30.0;
+                public static final double L3 = 31.0;
                 public static final double L4 = 54.9;
                 public static final double ARM_WILL_NOT_HIT_BASE_HEIGHT = 20.0;
                 public static final double STAGE_1_LENGTH = 29;
                 public static final double STAGE_2_LENGTH = 26;
-                public static final double GEAR_RATIO = 50 / 7; // 7.41:1
+                public static final double GEAR_RATIO = 50 / 7;
                 public static final double FLOOR_TO_ELEVATOR_TOP = 70.88;
                 public static final double FLOOR_TO_TOP_OF_BOTTOM_TUBE = 11.88;
                 public static final double MAX_VELOCITY = 4000;
@@ -115,9 +115,9 @@ public final class Constants {
                 public static final double GROUND_ALGAE_POSITION = 95;
                 public static final double CORAL_STATION_POSITION = 323;
                 public static final double L1_UNDERHAND = 335.0;
-                public static final double L1_POSITION = 140.0;
-                public static final double L2_POSITION = 135.0;
-                public static final double L3_POSITION = 135.0;
+                public static final double L1_POSITION = 120.0;
+                public static final double L2_POSITION = 140.0;
+                public static final double L3_POSITION = 140.0;
                 public static final double L4_POSITION = 140.0;
                 public static final double BARGE_POSITION = 159.0;
                 public static final double PROCESSOR_POSITION = 270.0;
@@ -210,19 +210,20 @@ public final class Constants {
         }
 
         public static class LimelightConstants {
-                // placeholder values (in meters)
+                // REEF CAMERA OFFSETS
                 public static final double CAMERA_FORWARD_OFFSET = 0.216;
                 public static final double CAMERA_SIDE_OFFSET = 0.121;
                 public static final double CAMERA_HEIGHT_OFFSET = 0.2404;
-                // placeholder values (in degrees)
+
                 public static final double CAMERA_ROLL_OFFSET = 0.0;
                 public static final double CAMERA_PITCH_OFFSET = 0.0;
                 public static final double CAMERA_YAW_OFFSET = -17.5;
-                // placeholder values (in meters)
+
                 public static final double CAMERA2_FORWARD_OFFSET = -0.216;
                 public static final double CAMERA2_SIDE_OFFSET = 0.121;
                 public static final double CAMERA2_HEIGHT_OFFSET = 0.84990178;
-                // placeholder values (in degrees)
+
+                // CORAL STATION CAMERA OFFSETS
                 public static final double CAMERA2_ROLL_OFFSET = 0.0;
                 public static final double CAMERA2_PITCH_OFFSET = 30.0;
                 public static final double CAMERA2_YAW_OFFSET = 180.0;

--- a/2025-Code/src/main/java/frc/robot/Constants.java
+++ b/2025-Code/src/main/java/frc/robot/Constants.java
@@ -136,7 +136,7 @@ public final class Constants {
 
                 public static final double GAIN_THRESHOLD = 6;
 
-                public static final double kp = 0.03;
+                public static final double kp = 0.025;
                 public static final double ki = 0;
                 public static final double kd = 0;
                 public static final double kp1 = 0.05;
@@ -182,8 +182,8 @@ public final class Constants {
                 public static final int GRAB_CURRENT_LIMIT = 10;
 
                 public static final int START_CLIMB_POSITION = 0;
-                public static final int RAISE_CLIMB_POSITION = 20;
-                public static final int LOWER_CLIMB_POSITION = -20;
+                public static final int RAISE_CLIMB_POSITION = 40;
+                public static final int LOWER_CLIMB_POSITION = -40;
 
                 public static final int CLIMB_POSITION_TOLERANCE = 3;
                 public static final int GRABBER_POSITION_TOLERANCE = 5;

--- a/2025-Code/src/main/java/frc/robot/Constants.java
+++ b/2025-Code/src/main/java/frc/robot/Constants.java
@@ -80,7 +80,7 @@ public final class Constants {
                 public static final double REMOVE_ALGAE_L3 = 50.0;
                 public static final double SCORE_ALGAE_BARGE = 54.9;
                 public static final double SCORE_ALGAE_PROCESSOR = 25.0;
-                public static final double L1 = 10.0;
+                public static final double L1 = 11.0;
                 public static final double L2 = 16.0;
                 public static final double L3 = 30.0;
                 public static final double L4 = 54.9;
@@ -100,6 +100,8 @@ public final class Constants {
                 public static final double STAGE_2_FF = 0.30;
                 public static final double HEIGHT_TOLERANCE = 0.6;
                 public static final double SLOW_MOVE_THRESHOLD = 45.0;
+                public static final double SAFE_HEIGHT_ALGAE = 30;
+                public static final double SAFE_HEIGHT_NO_ALGAE = 16;
         }
 
         public static class ArmConstants {

--- a/2025-Code/src/main/java/frc/robot/Constants.java
+++ b/2025-Code/src/main/java/frc/robot/Constants.java
@@ -115,9 +115,9 @@ public final class Constants {
                 public static final double GROUND_ALGAE_POSITION = 95;
                 public static final double CORAL_STATION_POSITION = 323;
                 public static final double L1_UNDERHAND = 335.0;
-                public static final double L1_POSITION = 120.0;
-                public static final double L2_POSITION = 140.0;
-                public static final double L3_POSITION = 140.0;
+                public static final double L1_POSITION = 130.0;
+                public static final double L2_POSITION = 141.0;
+                public static final double L3_POSITION = 141.0;
                 public static final double L4_POSITION = 140.0;
                 public static final double BARGE_POSITION = 159.0;
                 public static final double PROCESSOR_POSITION = 270.0;
@@ -277,12 +277,12 @@ public final class Constants {
                 // right is more negative, left is more positive
                 public static final double offsetOfArmStation = -.42;
                 public static final double sidewaysOffsetStation = .3;
-                public static final double offsetToReef = .515;
+                public static final double offsetToReef = .52;
                 public static final double offsetToStation = .58;
                 public static final double reefWidth = 0.33;
 
                 public static final double offsetOfArmAlgae = 0.33;
-                public static final double offsetToReefAlgae = 0.09;
+                public static final double offsetToReefAlgae = 0.7;
                 // negative is more right
 
                 // CURRENTLY TESTING WITH THIS LIBRARY THING

--- a/2025-Code/src/main/java/frc/robot/Constants.java
+++ b/2025-Code/src/main/java/frc/robot/Constants.java
@@ -387,5 +387,4 @@ public final class Constants {
                                 CalculateAlgaePoint(layout.getTagPose(21).get()),
                                 CalculateAlgaePoint(layout.getTagPose(22).get()));
         }
-
 }

--- a/2025-Code/src/main/java/frc/robot/Constants.java
+++ b/2025-Code/src/main/java/frc/robot/Constants.java
@@ -117,7 +117,7 @@ public final class Constants {
                 public static final double L2_POSITION = 135.0;
                 public static final double L3_POSITION = 135.0;
                 public static final double L4_POSITION = 133.0;
-                public static final double BARGE_POSITION = 180.0;
+                public static final double BARGE_POSITION = 159.0;
                 public static final double PROCESSOR_POSITION = 270.0;
                 public static final double EVACUATE_ANGLE = 15.0;
                 public static final double REEF_DESCORE_POSITION = 50.0;

--- a/2025-Code/src/main/java/frc/robot/RobotContainer.java
+++ b/2025-Code/src/main/java/frc/robot/RobotContainer.java
@@ -8,6 +8,7 @@ import frc.robot.Constants.OperatorConstants;
 import static frc.robot.Constants.DriveToPoint.*;
 import frc.robot.command_factories.*;
 import frc.robot.commands.DriveToPointCommand;
+import frc.robot.subsystems.Algae;
 import frc.robot.util.Subsystem;
 
 import static frc.robot.util.Subsystem.*;
@@ -69,11 +70,13 @@ public class RobotContainer {
     m_buttonsController.b().whileTrue(SuperstructureFactory.scoreL3(m_buttonsController));
     m_buttonsController.a().whileTrue(SuperstructureFactory.scoreL4(m_buttonsController));
 
-    m_buttonsController.rightTrigger().whileTrue(SuperstructureFactory.descoreAlgaeL3());
-    m_buttonsController.leftTrigger().whileTrue(SuperstructureFactory.descoreAlgaeL2());
-    m_buttonsController.back().whileTrue(SuperstructureFactory.scoreProcessorCommand(m_buttonsController));
-    m_buttonsController.start().whileTrue(SuperstructureFactory.scoreBargeCommand(m_buttonsController));
-    m_buttonsController.povDown().whileTrue(AlgaeFactory.runOuttake());
+    m_buttonsController.start().whileTrue(AlgaeFactory.runOuttake());
+
+    m_buttonsController.povUp().whileTrue(SuperstructureFactory.scoreBargeCommand(m_buttonsController));
+    m_buttonsController.povDown().whileTrue(SuperstructureFactory.scoreProcessorCommand(m_buttonsController));
+
+    m_buttonsController.povLeft().whileTrue(SuperstructureFactory.descoreAlgaeL2());
+    m_buttonsController.povRight().whileTrue(SuperstructureFactory.descoreAlgaeL3());
 
     m_buttonsController.leftBumper().whileTrue(SuperstructureFactory.intakeCoral());
   }

--- a/2025-Code/src/main/java/frc/robot/RobotContainer.java
+++ b/2025-Code/src/main/java/frc/robot/RobotContainer.java
@@ -53,7 +53,6 @@ public class RobotContainer {
     // driver controller
     // ONLY RUN CLIMB IN ORDER AS LISTED BELOW vvv
     m_driverController.y().onTrue(ClimbFactory.raiseClimb());
-    m_driverController.x().onTrue(ClimbFactory.lockGrabber());
     m_driverController.a().onTrue(ClimbFactory.lowerClimb());
 
     m_driverController.back().whileTrue(swerve.resetYawCommand());

--- a/2025-Code/src/main/java/frc/robot/command_factories/SuperstructureFactory.java
+++ b/2025-Code/src/main/java/frc/robot/command_factories/SuperstructureFactory.java
@@ -43,13 +43,13 @@ public class SuperstructureFactory {
     public static Command scoreBargeCommand(CommandXboxController controller) {
         Command elevatorCom = ElevatorFactory.moveToScoreBarge();
         Command armScoreCom = ArmFactory.armToScoreBarge();
-        Command algaeDefaultCom = algae.algaeDefaultCommand();
+        // Command algaeDefaultCom = algae.algaeDefaultCommand();
         Command algaeScoreCom = AlgaeFactory.runOuttake();
         BooleanSupplier readyToScore = () -> (arm.readyToScore() && elevator.readyToScore()
                 && controller.getHID().getRightBumperButton());
         BooleanSupplier comEnd = () -> !algae.debouncedHasAlgae();
 
-        return ((elevatorCom.alongWith(armScoreCom, algaeDefaultCom))
+        return ((elevatorCom.alongWith(armScoreCom))
                 .until(readyToScore)).andThen(algaeScoreCom.until(comEnd));
     }
 

--- a/2025-Code/src/main/java/frc/robot/command_factories/SuperstructureFactory.java
+++ b/2025-Code/src/main/java/frc/robot/command_factories/SuperstructureFactory.java
@@ -43,7 +43,6 @@ public class SuperstructureFactory {
     public static Command scoreBargeCommand(CommandXboxController controller) {
         Command elevatorCom = ElevatorFactory.moveToScoreBarge();
         Command armScoreCom = ArmFactory.armToScoreBarge();
-        // Command algaeDefaultCom = algae.algaeDefaultCommand();
         Command algaeScoreCom = AlgaeFactory.runOuttake();
         BooleanSupplier readyToScore = () -> (arm.readyToScore() && elevator.readyToScore()
                 && controller.getHID().getRightBumperButton());

--- a/2025-Code/src/main/java/frc/robot/commands/DriveToPointCommand.java
+++ b/2025-Code/src/main/java/frc/robot/commands/DriveToPointCommand.java
@@ -79,6 +79,15 @@ public class DriveToPointCommand extends Command {
     List<Pose2d> m_coralStationPoses = redAlliance.get() ? POSE_LIST.subList(0, 6) : POSE_LIST.subList(6, 12);
     m_localList = (hasGamePiece || m_algae) ? m_reefPoses : m_coralStationPoses;
     m_pointControl.setTargetNearest(m_localList);
+    if (hasGamePiece || m_algae) {
+      m_localList = m_algae ? REEF_ALGAE : (redAlliance.get() ? RED_REEF : BLUE_REEF);
+    } else {
+      if (m_localList.indexOf(m_pointControl.getTarget()) < 3) {
+        m_localList = m_localList.subList(0, 3);
+      } else {
+        m_localList = m_localList.subList(3, 6);
+      }
+    }
   }
 
   public void isAtPoint() {

--- a/2025-Code/src/main/java/frc/robot/commands/DriveToPointCommand.java
+++ b/2025-Code/src/main/java/frc/robot/commands/DriveToPointCommand.java
@@ -25,7 +25,7 @@ public class DriveToPointCommand extends Command {
   private List<Pose2d> m_localList;
   private boolean m_bumperWasPressed = false;
   private boolean m_hadGamePiece;
-  private final boolean m_algae;
+  private boolean m_algae;
 
   public DriveToPointCommand(CommandXboxController xboxController, boolean algae) {
     m_algae = algae;
@@ -47,6 +47,9 @@ public class DriveToPointCommand extends Command {
 
   @Override
   public void execute() {
+    if (m_xboxController.getHID().getRightTriggerAxis() > 0.1) {
+      m_algae = true;
+    }
     if (!m_algae) {
       checkBumpers();
     }
@@ -78,7 +81,7 @@ public class DriveToPointCommand extends Command {
     List<Pose2d> m_coralStationPoses = redAlliance.get() ? POSE_LIST.subList(0, 6) : POSE_LIST.subList(6, 12);
     m_localList = hasGamePiece ? m_reefPoses : m_coralStationPoses;
     m_pointControl.setTargetNearest(m_localList);
-    if (hasGamePiece) {
+    if (hasGamePiece || m_algae) {
       m_localList = m_algae ? REEF_ALGAE : (redAlliance.get() ? RED_REEF : BLUE_REEF);
     } else {
       if (m_localList.indexOf(m_pointControl.getTarget()) < 3) {

--- a/2025-Code/src/main/java/frc/robot/commands/DriveToPointCommand.java
+++ b/2025-Code/src/main/java/frc/robot/commands/DriveToPointCommand.java
@@ -47,9 +47,6 @@ public class DriveToPointCommand extends Command {
 
   @Override
   public void execute() {
-    if (m_xboxController.getHID().getRightTriggerAxis() > 0.1) {
-      m_algae = true;
-    }
     if (!m_algae) {
       checkBumpers();
     }
@@ -58,6 +55,7 @@ public class DriveToPointCommand extends Command {
     if (swerve.isAtPoint() && (Subsystem.coral.hasCoral() != m_hadGamePiece)) {
       obtainTarget();
     }
+    System.out.println("algae:" + m_algae);
   }
 
   @Override
@@ -79,17 +77,8 @@ public class DriveToPointCommand extends Command {
     m_hadGamePiece = hasGamePiece;
     List<Pose2d> m_reefPoses = m_algae ? REEF_ALGAE : (redAlliance.get() ? RED_REEF_RIGHT : BLUE_REEF_RIGHT);
     List<Pose2d> m_coralStationPoses = redAlliance.get() ? POSE_LIST.subList(0, 6) : POSE_LIST.subList(6, 12);
-    m_localList = hasGamePiece ? m_reefPoses : m_coralStationPoses;
+    m_localList = (hasGamePiece || m_algae) ? m_reefPoses : m_coralStationPoses;
     m_pointControl.setTargetNearest(m_localList);
-    if (hasGamePiece || m_algae) {
-      m_localList = m_algae ? REEF_ALGAE : (redAlliance.get() ? RED_REEF : BLUE_REEF);
-    } else {
-      if (m_localList.indexOf(m_pointControl.getTarget()) < 3) {
-        m_localList = m_localList.subList(0, 3);
-      } else {
-        m_localList = m_localList.subList(3, 6);
-      }
-    }
   }
 
   public void isAtPoint() {

--- a/2025-Code/src/main/java/frc/robot/commands/DriveToPointCommand.java
+++ b/2025-Code/src/main/java/frc/robot/commands/DriveToPointCommand.java
@@ -55,7 +55,6 @@ public class DriveToPointCommand extends Command {
     if (swerve.isAtPoint() && (Subsystem.coral.hasCoral() != m_hadGamePiece)) {
       obtainTarget();
     }
-    System.out.println("algae:" + m_algae);
   }
 
   @Override

--- a/2025-Code/src/main/java/frc/robot/subsystems/Algae.java
+++ b/2025-Code/src/main/java/frc/robot/subsystems/Algae.java
@@ -82,6 +82,8 @@ public class Algae extends SubsystemBase {
         return run(() -> {
             if (hasAlgae()) {
                 m_voltage = HOLD_PIECE_VOLTAGE;
+            } else {
+                m_voltage = 0;
             }
         });
     }

--- a/2025-Code/src/main/java/frc/robot/subsystems/Arm.java
+++ b/2025-Code/src/main/java/frc/robot/subsystems/Arm.java
@@ -65,7 +65,7 @@ public class Arm extends SubsystemBase {
 
   public boolean readyToScore() {
     return atTargetAngle() && !(m_targetAngle == DEFAULT_POSITION
-        || m_targetAngle == DEFAULT_BACK_POSITION
+        || m_targetAngle == DEFAULT_NO_GP
         || m_targetAngle == CORAL_STATION_POSITION);
   }
 
@@ -165,11 +165,11 @@ public class Arm extends SubsystemBase {
         safeAngle = DEFAULT_POSITION;
       }
     }
-    if (getAngle() > 180 && getTargetAngle() < DEFAULT_BACK_POSITION) {
-      safeAngle = DEFAULT_BACK_POSITION;
+    if (getAngle() > 180 && getTargetAngle() < SAFE_BACK_POS) {
+      safeAngle = SAFE_BACK_POS;
     }
     if (getTargetAngle() > 270) {
-      safeAngle = DEFAULT_BACK_POSITION;
+      safeAngle = SAFE_BACK_POS;
     }
 
     return safeAngle;
@@ -192,10 +192,10 @@ public class Arm extends SubsystemBase {
       if (Subsystem.coral.hasCoral()) {
         m_targetAngle = DEFAULT_POSITION;
         if (Subsystem.algae.debouncedHasAlgae()) {
-          m_targetAngle = DEFAULT_BACK_POSITION;
+          m_targetAngle = DEFAULT_NO_GP;
         }
       } else {
-        m_targetAngle = DEFAULT_BACK_POSITION;
+        m_targetAngle = DEFAULT_NO_GP;
       }
     });
   }

--- a/2025-Code/src/main/java/frc/robot/subsystems/Arm.java
+++ b/2025-Code/src/main/java/frc/robot/subsystems/Arm.java
@@ -198,6 +198,7 @@ public class Arm extends SubsystemBase {
         m_targetAngle = DEFAULT_NO_GP;
       }
     });
+
   }
 
   /**

--- a/2025-Code/src/main/java/frc/robot/subsystems/Arm.java
+++ b/2025-Code/src/main/java/frc/robot/subsystems/Arm.java
@@ -64,7 +64,7 @@ public class Arm extends SubsystemBase {
   }
 
   public boolean readyToScore() {
-    return atTargetAngle() && !(m_targetAngle == STARTING_POSITION || m_targetAngle == DEFAULT_POSITION
+    return atTargetAngle() && !(m_targetAngle == DEFAULT_POSITION
         || m_targetAngle == DEFAULT_BACK_POSITION
         || m_targetAngle == CORAL_STATION_POSITION);
   }
@@ -191,6 +191,9 @@ public class Arm extends SubsystemBase {
     return run(() -> {
       if (Subsystem.coral.hasCoral()) {
         m_targetAngle = DEFAULT_POSITION;
+        if (Subsystem.algae.debouncedHasAlgae()) {
+          m_targetAngle = DEFAULT_BACK_POSITION;
+        }
       } else {
         m_targetAngle = DEFAULT_BACK_POSITION;
       }

--- a/2025-Code/src/main/java/frc/robot/subsystems/Climb.java
+++ b/2025-Code/src/main/java/frc/robot/subsystems/Climb.java
@@ -142,11 +142,10 @@ public class Climb extends SubsystemBase {
 
   public Command lowerClimbCommand() {
     return run(() -> {
-      m_targetPositionGrab = LOCK_GRABBER_POSITION;
       m_targetPositionRatchet = RATCHET_UNLOCK_POSITION;
       m_climbMotorOff = false;
       m_targetPositionClimb = LOWER_CLIMB_POSITION;
-    }).onlyIf(() -> isLowerClimbSafe()).until(() -> isLowerPosition());
+    }).until(() -> isLowerPosition());
   }
 
   public Command hasClimbCommand() {
@@ -214,7 +213,6 @@ public class Climb extends SubsystemBase {
     return m_grabEncoder.getPosition();
   }
 
-  
   public void changePID(double p, double i, double d) {
     m_climbMotorConfig.Slot0.kP = p;
     m_climbMotorConfig.Slot0.kI = i;

--- a/2025-Code/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/2025-Code/src/main/java/frc/robot/subsystems/Elevator.java
@@ -141,7 +141,8 @@ public class Elevator extends SubsystemBase {
   }
 
   public boolean readyToScore() {
-    return atTargetHeight() && !(m_targetHeight == DEFAULT || m_targetHeight == CORAL_INTAKE);
+    return atTargetHeight() && !(m_targetHeight == DEFAULT_NO_CORAL || m_targetHeight == CORAL_INTAKE
+        || m_targetHeight == DEFAULT_WITH_CORAL);
   }
 
   private double safeHeight(double targetHeight) {
@@ -156,7 +157,7 @@ public class Elevator extends SubsystemBase {
     else if ((((Subsystem.arm.getTargetAngle() > 180 && Subsystem.arm.getAngle() < 180)
         || (Subsystem.arm.getTargetAngle() < 180 && Subsystem.arm.getAngle() > 180))
         || (Subsystem.arm.getAngle() > ArmConstants.DEFAULT_POSITION + ArmConstants.DRIVING_ANGLE_TOLERANCE
-            && Subsystem.arm.getAngle() < ArmConstants.DEFAULT_BACK_POSITION - ArmConstants.DRIVING_ANGLE_TOLERANCE))
+            && Subsystem.arm.getAngle() < ArmConstants.DEFAULT_NO_GP - ArmConstants.DRIVING_ANGLE_TOLERANCE))
         && getTargetHeight() < safeHeight) {
       safeTarget = safeHeight;
     }
@@ -198,7 +199,13 @@ public class Elevator extends SubsystemBase {
   }
 
   public Command elevatorDefaultCommand() {
-    return run(() -> m_targetHeight = DEFAULT);
+    return run(() -> {
+      if (Subsystem.coral.debouncedHasCoral()) {
+        m_targetHeight = DEFAULT_WITH_CORAL;
+      } else {
+        m_targetHeight = DEFAULT_NO_CORAL;
+      }
+    });
   }
 
   public Command moveElevatorCommand(double height) {

--- a/2025-Code/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/2025-Code/src/main/java/frc/robot/subsystems/Elevator.java
@@ -146,19 +146,19 @@ public class Elevator extends SubsystemBase {
 
   private double safeHeight(double targetHeight) {
     double safeTarget = targetHeight;
+    double safeHeight = Subsystem.algae.hasAlgae() ? SAFE_HEIGHT_ALGAE : SAFE_HEIGHT_NO_ALGAE;
 
     if ((Subsystem.arm.getAngle() < 90 || Subsystem.arm.getAngle() > 270 || Subsystem.arm.getTargetAngle() < 90
-        || Subsystem.arm.getTargetAngle() > 270) && (getTargetHeight() < L2)) {
-      safeTarget = L2;
+        || Subsystem.arm.getTargetAngle() > 270) && (getTargetHeight() < safeHeight)) {
+      safeTarget = safeHeight;
     }
 
     else if ((((Subsystem.arm.getTargetAngle() > 180 && Subsystem.arm.getAngle() < 180)
         || (Subsystem.arm.getTargetAngle() < 180 && Subsystem.arm.getAngle() > 180))
         || (Subsystem.arm.getAngle() > ArmConstants.DEFAULT_POSITION + ArmConstants.DRIVING_ANGLE_TOLERANCE
-            && Subsystem.arm.getAngle() < ArmConstants.DEFAULT_BACK_POSITION - ArmConstants.DRIVING_ANGLE_TOLERANCE)
-        || (Subsystem.arm.getTargetAngle() > ArmConstants.DEFAULT_POSITION && Subsystem.algae.debouncedHasAlgae()))
-        && getTargetHeight() < L2 + 2) {
-      safeTarget = L2 + 2;
+            && Subsystem.arm.getAngle() < ArmConstants.DEFAULT_BACK_POSITION - ArmConstants.DRIVING_ANGLE_TOLERANCE))
+        && getTargetHeight() < safeHeight) {
+      safeTarget = safeHeight;
     }
 
     return safeTarget;

--- a/2025-Code/src/main/java/frc/robot/subsystems/Limelight.java
+++ b/2025-Code/src/main/java/frc/robot/subsystems/Limelight.java
@@ -257,7 +257,7 @@ public class Limelight extends SubsystemBase {
       // LL4 internal IMU's fused yaw to match the submitted yaw value
       LimelightHelpers.SetIMUMode(LL_STATION, 1);
     } else {
-      LimelightHelpers.SetIMUMode(LL_REEF, 1); // 2
+      LimelightHelpers.SetIMUMode(LL_REEF, 1);
       // use internal IMU for MT2 localization. External IMU data is ignored entirely.
       LimelightHelpers.SetIMUMode(LL_STATION, 1);
     }

--- a/2025-Code/src/main/java/frc/robot/subsystems/Limelight.java
+++ b/2025-Code/src/main/java/frc/robot/subsystems/Limelight.java
@@ -257,9 +257,9 @@ public class Limelight extends SubsystemBase {
       // LL4 internal IMU's fused yaw to match the submitted yaw value
       LimelightHelpers.SetIMUMode(LL_STATION, 1);
     } else {
-      LimelightHelpers.SetIMUMode(LL_REEF, 2);
+      LimelightHelpers.SetIMUMode(LL_REEF, 1); // 2
       // use internal IMU for MT2 localization. External IMU data is ignored entirely.
-      LimelightHelpers.SetIMUMode(LL_STATION, 2);
+      LimelightHelpers.SetIMUMode(LL_STATION, 1);
     }
 
     // according to limelight docs, this needs to be called before using


### PR DESCRIPTION
Important stuff:
- changed scoring positions to account for new elevator and arm speeds.
- changed elevator defaults to account for algae and allow us to reset the encoders throughout the match
- limelight imu modes set to 1 to fix bug. needs to be looked into further.
- climb made to work with new mechanism. not a full cleanup, there is a branch out there but this should be merged first.
- algae buttons changed to be all on dpad except for outtake (start)
- logic for drivetopoint fixed to allow for algae autoalign as well as the other stuff
- i think thats it. probably forgot something feel free to flame me